### PR TITLE
Validate alternative recipe selection

### DIFF
--- a/ah_mealplanner/web/routes.py
+++ b/ah_mealplanner/web/routes.py
@@ -733,6 +733,12 @@ def admin_recent():
 def alternatives(item_id: int, plan_id: int):
     if request.method == "POST":
         new_recipe_id = request.form.get("recipe_id")
+        if not new_recipe_id:
+            return ("No recipe selected", 400)
+        try:
+            new_recipe_id = int(new_recipe_id)
+        except ValueError:
+            return ("Invalid recipe id", 400)
         with _conn() as conn:
             conn.execute("update meal_plan_items set item_id = ? where id = ?", (new_recipe_id, item_id))
             _recalculate_plan_totals(conn, plan_id)

--- a/ah_mealplanner/web/templates/alternatives.html
+++ b/ah_mealplanner/web/templates/alternatives.html
@@ -11,7 +11,7 @@
     <ul>
       {% for alt in alternatives %}
         <li>
-          <input type="radio" name="recipe_id" value="{{ alt['id'] }}" id="alt_{{ alt['id'] }}">
+          <input type="radio" name="recipe_id" value="{{ alt['id'] }}" id="alt_{{ alt['id'] }}" required>
           <label for="alt_{{ alt['id'] }}">
             <a href="{{ url_for('core.recipe_detail', rid=alt['id']) }}">{{ alt['title'] }}</a>
           </label>


### PR DESCRIPTION
## Summary
- prevent meal plan updates with missing or invalid alternative recipe ids
- ensure alternative recipe must be selected in swap form

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68acae881cc4832e983e7c86d9903055