### PR TITLE
feat: add EatThisMuch ingestion

### DIFF
--- a/ah_mealplanner/cli.py
+++ b/ah_mealplanner/cli.py
@@ -7,6 +7,7 @@ from typing import List
 from . import db
 from .ingest_allerhande import fetch_recipe, crawl_allerhande, enrich_recipe
 from .ingest_ah import import_products_from_csv, import_products_from_json, crawl_ah_products
+from .ingest_eatthismuch import crawl_etm_foods, crawl_etm_recipes
 from .http import fetch
 from .ingest_allerhande import _extract_json_ld, _first_recipe, _extract_nutrition_from_jsonld, _extract_nutrition_from_html
 from .meal_planner import generate_daily_plan, generate_weekly_plan
@@ -137,6 +138,20 @@ def cmd_crawl_ah_products(args):
     print(f"Ingested {ingested} AH products from sitemaps")
 
 
+def cmd_crawl_etm_foods(args):
+    with db.connect() as conn:
+        db.init_db(conn)
+        ingested = crawl_etm_foods(conn, limit=args.limit, delay_s=args.delay)
+    print(f"Ingested {ingested} EatThisMuch foods")
+
+
+def cmd_crawl_etm_recipes(args):
+    with db.connect() as conn:
+        db.init_db(conn)
+        ingested = crawl_etm_recipes(conn, limit=args.limit, delay_s=args.delay)
+    print(f"Ingested {ingested} EatThisMuch recipes")
+
+
 def build_parser():
     p = argparse.ArgumentParser(description="AH Personal Meal Planner")
     sub = p.add_subparsers(dest="cmd")
@@ -183,6 +198,16 @@ def build_parser():
     s.add_argument("--limit", type=int, default=200, help="max products to ingest")
     s.add_argument("--sitemap", action="append", help="seed sitemap URL(s)")
     s.set_defaults(func=cmd_crawl_ah_products)
+
+    s = sub.add_parser("crawl-etm-foods", help="ingest foods from the EatThisMuch API")
+    s.add_argument("--limit", type=int, default=100, help="max foods to ingest")
+    s.add_argument("--delay", type=float, default=0.2, help="delay between API calls in seconds")
+    s.set_defaults(func=cmd_crawl_etm_foods)
+
+    s = sub.add_parser("crawl-etm-recipes", help="ingest recipes from the EatThisMuch API")
+    s.add_argument("--limit", type=int, default=100, help="max recipes to ingest")
+    s.add_argument("--delay", type=float, default=0.2, help="delay between API calls in seconds")
+    s.set_defaults(func=cmd_crawl_etm_recipes)
 
     s = sub.add_parser("refresh-nutrition", help="refresh nutrition fields for recipes (parse from recipe pages)")
     s.add_argument("--limit", type=int, default=2000, help="max recipes to update")

--- a/ah_mealplanner/ingest_eatthismuch.py
+++ b/ah_mealplanner/ingest_eatthismuch.py
@@ -1,0 +1,121 @@
+import json
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional, Tuple
+from urllib.parse import urljoin
+
+from .http import fetch
+from .db import upsert_product, insert_recipe, insert_recipe_tags
+
+ETM_BASE = "https://www.eatthismuch.com"
+
+
+def _get_json(path: str, delay_s: float) -> Dict:
+    url = urljoin(ETM_BASE, path)
+    status, data = fetch(url, delay_s=delay_s)
+    if status != 200:
+        raise ValueError(f"HTTP {status}: {url}")
+    return json.loads(data)
+
+
+def _food_to_row(obj: Dict) -> Dict:
+    img = obj.get("default_image", {}) or {}
+    image_url = urljoin(ETM_BASE + "/", img.get("image", "")) if img.get("image") else None
+    public_url = obj.get("public_url") or obj.get("canonical_url")
+    url = urljoin(ETM_BASE + "/", public_url.lstrip("/")) if public_url else None
+    sodium = obj.get("sodium")
+    salt_g = sodium / 1000.0 if sodium is not None else None
+    row = {
+        "ah_id": f"etm_food_{obj.get('id')}",
+        "name": obj.get("food_name"),
+        "brand": obj.get("manufactured_by"),
+        "category": str(obj.get("food_group")) if obj.get("food_group") is not None else None,
+        "unit": "g",
+        "price_eur": obj.get("price"),
+        "kcal_per_100": obj.get("calories"),
+        "protein_g_per_100": obj.get("proteins"),
+        "carbs_g_per_100": obj.get("carbs"),
+        "fat_g_per_100": obj.get("fats"),
+        "fiber_g_per_100": obj.get("fiber"),
+        "salt_g_per_100": salt_g,
+        "nutrition_json": json.dumps(obj.get("nutrition")) if obj.get("nutrition") else None,
+        "url": url,
+        "image_url": image_url,
+        "last_seen": datetime.utcnow().isoformat(),
+    }
+    return row
+
+
+def crawl_etm_foods(conn, limit: Optional[int] = 100, delay_s: float = 0.2) -> int:
+    count = 0
+    next_path: Optional[str] = "/api/v1/food/?page=1"
+    while next_path and (limit is None or count < limit):
+        data = _get_json(next_path, delay_s)
+        for obj in data.get("objects", []):
+            row = _food_to_row(obj)
+            upsert_product(conn, row)
+            count += 1
+            if limit is not None and count >= limit:
+                break
+        next_path = data.get("meta", {}).get("next")
+    return count
+
+
+def _recipe_from_obj(obj: Dict) -> Tuple[Dict, List[Dict], List[Dict]]:
+    img = obj.get("default_image", {}) or {}
+    image_url = urljoin(ETM_BASE + "/", img.get("image", "")) if img.get("image") else None
+    public_url = obj.get("public_url") or obj.get("canonical_url")
+    url = urljoin(ETM_BASE + "/", public_url.lstrip("/")) if public_url else None
+    directions = "\n".join(d.get("text", "").strip() for d in obj.get("directions", []) if d.get("text"))
+    recipe_row = {
+        "source": "eatthismuch",
+        "source_id": str(obj.get("id")),
+        "title": obj.get("food_name"),
+        "url": url,
+        "image_url": image_url,
+        "servings": obj.get("number_servings"),
+        "total_time_min": obj.get("total_time"),
+        "kcal_per_serving": obj.get("serving_calories"),
+        "protein_g_per_serving": obj.get("serving_proteins"),
+        "carbs_g_per_serving": obj.get("serving_carbs"),
+        "fat_g_per_serving": obj.get("serving_fats"),
+        "fiber_g_per_serving": obj.get("fiber"),
+        "instructions": directions,
+        "raw_json": json.dumps(obj),
+        "last_seen": datetime.utcnow().isoformat(),
+    }
+    ingredients: List[Dict] = []
+    for ing in obj.get("ingredients", []):
+        food = ing.get("food", {}) or {}
+        ingredients.append(
+            {
+                "name": food.get("food_name"),
+                "quantity": ing.get("amount"),
+                "unit": str(ing.get("units")) if ing.get("units") is not None else None,
+                "product_id": None,
+                "raw": json.dumps(ing),
+            }
+        )
+    tags: List[Dict] = []
+    tag_cloud = obj.get("tag_cloud") or []
+    if isinstance(tag_cloud, list):
+        for t in tag_cloud:
+            tags.append({"tag": t, "type": None})
+    return recipe_row, ingredients, tags
+
+
+def crawl_etm_recipes(conn, limit: Optional[int] = 100, delay_s: float = 0.2) -> int:
+    count = 0
+    next_path: Optional[str] = "/api/v1/recipe/?page=1"
+    while next_path and (limit is None or count < limit):
+        data = _get_json(next_path, delay_s)
+        for obj in data.get("objects", []):
+            recipe_row, ingredients, tags = _recipe_from_obj(obj)
+            rid = insert_recipe(conn, recipe_row, ingredients)
+            if tags:
+                insert_recipe_tags(conn, rid, tags)
+            count += 1
+            if limit is not None and count >= limit:
+                break
+        next_path = data.get("meta", {}).get("next")
+    return count
+


### PR DESCRIPTION
## Summary
- add `ingest_eatthismuch` module for foods and recipes API
- expose CLI commands to import EatThisMuch foods and recipes

## Testing
- `python -m pytest`
- `AH_MEALPLANNER_DB=/tmp/etm.db python -m ah_mealplanner.cli crawl-etm-foods --limit 1 --delay 0.1`
- `AH_MEALPLANNER_DB=/tmp/etm.db python -m ah_mealplanner.cli crawl-etm-recipes --limit 1 --delay 0.1`


------
https://chatgpt.com/codex/tasks/task_e_68acbf4cde98832e8c9ea74943a3b2f5