### PR TITLE
Handle string tag_cloud for EatThisMuch recipes

### DIFF
--- a/ah_mealplanner/ingest_eatthismuch.py
+++ b/ah_mealplanner/ingest_eatthismuch.py
@@ -110,10 +110,14 @@ def _recipe_from_obj(obj: Dict) -> Tuple[Dict, List[Dict], List[Dict]]:
             }
         )
     tags: List[Dict] = []
-    tag_cloud = obj.get("tag_cloud") or []
+    tag_cloud = obj.get("tag_cloud")
+    tag_items: List[str] = []
     if isinstance(tag_cloud, list):
-        for t in tag_cloud:
-            tags.append({"tag": t, "type": None})
+        tag_items = tag_cloud
+    elif isinstance(tag_cloud, str):
+        tag_items = [t.strip().strip('"') for t in tag_cloud.split() if t.strip()]
+    for t in tag_items:
+        tags.append({"tag": t, "type": None})
     return recipe_row, ingredients, tags
 
 


### PR DESCRIPTION
## Summary
- handle EatThisMuch recipe tag_cloud fields that return strings instead of lists

## Testing
- `python -m py_compile ah_mealplanner/ingest_eatthismuch.py`


------
https://chatgpt.com/codex/tasks/task_e_68accd6f0908832eb51536f4d22123c0