### PR TITLE
Improve macro target defaults in meal planner

### DIFF
--- a/ah_mealplanner/meal_planner.py
+++ b/ah_mealplanner/meal_planner.py
@@ -60,6 +60,16 @@ def generate_daily_plan(
     slot_names: Optional[List[str]] = None,
 ):
     exclusions = exclusions or []
+    if macro_targets is None:
+        try:
+            p_ratio, f_ratio, c_ratio = macro_split
+            macro_targets = {
+                "protein_g": target_calories * p_ratio / 4.0,
+                "fat_g": target_calories * f_ratio / 9.0,
+                "carbs_g": target_calories * c_ratio / 4.0,
+            }
+        except Exception:
+            macro_targets = None
     cur = conn.cursor()
     recipes = cur.execute("SELECT * FROM recipes").fetchall()
     products = cur.execute("SELECT * FROM products").fetchall()


### PR DESCRIPTION
## Summary
- derive default protein, fat, and carb gram targets from the macro split when explicit macro targets are not provided

## Testing
- `python3 -m py_compile ah_mealplanner/meal_planner.py`
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad4656a728832e8c24d9e76d95b9a3